### PR TITLE
gradle-bin: fix build script by removing unzip command

### DIFF
--- a/gradle-bin/build
+++ b/gradle-bin/build
@@ -2,7 +2,5 @@
 
 version=6.3
 
-unzip gradle-$version-bin.zip
-
 mkdir -p "$1/usr/gradle/gradle-bin"
 mv gradle-$version/* "$1/usr/gradle/gradle-bin/"


### PR DESCRIPTION
gradle-bin currently fails to build as the package manager does the unzip